### PR TITLE
Fix missing translations

### DIFF
--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -23,7 +23,11 @@
     "games":     "Games",
     "gamesDesc": "Dive into the WebGL prototype",
     "novel":     "Books",
-    "novelDesc": "Flip through my light novel"
+    "novelDesc": "Flip through my light novel",
+    "playGame": "Play now",
+    "leaderboard": "Leaderboard",
+    "chapter1Title": "Chapter 1",
+    "novelAbout": "About the novel"
   },
   "history": {
     "title": "Site History",

--- a/src/locales/it/translation.json
+++ b/src/locales/it/translation.json
@@ -23,7 +23,11 @@
     "games":     "Giochi",
     "gamesDesc": "Immergiti nel prototipo WebGL",
     "novel":     "Libri",
-    "novelDesc": "Sfoglia la mia light novel"
+    "novelDesc": "Sfoglia la mia light novel",
+    "playGame": "Avvia il gioco",
+    "leaderboard": "Classifica",
+    "chapter1Title": "Capitolo 1",
+    "novelAbout": "Informazioni sulla novel"
   },
   "history": {
     "title": "Storia del sito",


### PR DESCRIPTION
## Summary
- add missing text for Creations links in English and Italian translations

## Testing
- `CI=true npm test --silent` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_683fef43a574832196702bf9bbf46d5d