### PR TITLE
Fix LanguageSwitcher comment

### DIFF
--- a/src/components/LanguageSwitcher.js
+++ b/src/components/LanguageSwitcher.js
@@ -1,4 +1,4 @@
-// src/components/LanguageSwitcher.jsx
+// src/components/LanguageSwitcher.js
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import ReactCountryFlag from 'react-country-flag';


### PR DESCRIPTION
## Summary
- fix header comment in LanguageSwitcher.js

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ffb5614188321a253a679e0d01913