### PR TITLE
Add example books pages

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -9,6 +9,9 @@ import WorkInProgress from './components/WorkInProgress';
 import History from './components/History';
 import CreationsPage from './components/CreationsPage';
 import Stocazzato from './components/Stocazzato';
+import BooksHome from './components/books/BooksHome';
+import BookOverview from './components/books/BookOverview';
+import BookChapter from './components/books/BookChapter';
 
 
 export default function App() {
@@ -24,6 +27,9 @@ export default function App() {
         {/* Rotta per gestire percorsi non definiti */}
         <Route path="*" element={<WorkInProgress />} />
         <Route path="/creations" element={<CreationsPage />} />
+        <Route path="/creations/books" element={<BooksHome />} />
+        <Route path="/creations/books/:type/:name/overview" element={<BookOverview />} />
+        <Route path="/creations/books/:type/:name/:chapter" element={<BookChapter />} />
         <Route path="/history" element={<History />} />
          <Route path="/stocazzato" element={<Stocazzato />} />
       </Routes>

--- a/src/components/CreationsPage.js
+++ b/src/components/CreationsPage.js
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { FaGamepad } from 'react-icons/fa';
 import { GiOpenBook } from 'react-icons/gi';
 import { motion, AnimatePresence } from 'framer-motion';
+import books from '../data/books';
 
 const iconTarget = { top: 5, left: 5, scale: 0.5 };
 const sparkleColors = { games: 'bg-yellow-300', novel: 'bg-emerald-300' };
@@ -142,10 +143,10 @@ export default function CreationsPage() {
           variant="novel"
           icon={<GiOpenBook className="text-6xl drop-shadow-lg" />}
           label={t('creations.novel')}
-          links={[
-            { href: '/novel/chapter-1', text: t('creations.chapter1Title') },
-            { href: '/novel/about', text: t('creations.novelAbout') }
-          ]}
+          links={books.map(b => ({
+            href: `/creations/books/${b.type}/${b.slug}/overview`,
+            text: b.title
+          }))}
           hovered={hovered === 'novel'}
           onHover={() => setHovered('novel')}
           onLeave={() => setHovered(null)}

--- a/src/components/books/BookChapter.js
+++ b/src/components/books/BookChapter.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import { useParams, Link } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import books from '../../data/books';
+
+export default function BookChapter() {
+  const { type, name, chapter } = useParams();
+  const { t } = useTranslation();
+  const book = books.find(b => b.type === type && b.slug === name);
+  if (!book) return <div className="p-8">Book not found</div>;
+  const index = book.chapters.findIndex(ch => ch.slug === chapter);
+  const ch = book.chapters[index];
+  if (!ch) return <div className="p-8">Chapter not found</div>;
+  const prev = index > 0 ? book.chapters[index - 1].slug : null;
+  const next = index < book.chapters.length - 1 ? book.chapters[index + 1].slug : null;
+
+  return (
+    <div className="container mx-auto px-8 py-20 max-w-2xl">
+      <h1 className="text-4xl font-bold mb-4">{book.title}</h1>
+      <h2 className="text-2xl font-semibold mb-4">{ch.title}</h2>
+      <p className="mb-8 whitespace-pre-line">{ch.content}</p>
+      <div className="flex justify-between">
+        {prev ? (
+          <Link
+            to={`/creations/books/${type}/${name}/${prev}`}
+            className="text-blue-600 dark:text-blue-400 hover:underline"
+          >
+            {t('books.prev')}
+          </Link>
+        ) : <span />}
+        {next ? (
+          <Link
+            to={`/creations/books/${type}/${name}/${next}`}
+            className="text-blue-600 dark:text-blue-400 hover:underline"
+          >
+            {t('books.next')}
+          </Link>
+        ) : <span />}
+      </div>
+    </div>
+  );
+}

--- a/src/components/books/BookOverview.js
+++ b/src/components/books/BookOverview.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import { useParams, Link } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import books from '../../data/books';
+
+export default function BookOverview() {
+  const { type, name } = useParams();
+  const { t } = useTranslation();
+  const book = books.find(b => b.type === type && b.slug === name);
+
+  if (!book) return <div className="p-8">Book not found</div>;
+
+  return (
+    <div className="container mx-auto px-8 py-20 max-w-2xl">
+      <h1 className="text-4xl font-bold mb-4">{book.title}</h1>
+      <p className="mb-6">{book.description}</p>
+      <h2 className="text-2xl font-semibold mb-2">{t('books.chapters')}</h2>
+      <ul className="list-disc list-inside space-y-1">
+        {book.chapters.map(ch => (
+          <li key={ch.slug}>
+            <Link
+              className="text-blue-600 dark:text-blue-400 hover:underline"
+              to={`/creations/books/${type}/${name}/${ch.slug}`}
+            >
+              {ch.title}
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/components/books/BooksHome.js
+++ b/src/components/books/BooksHome.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import books from '../../data/books';
+
+export default function BooksHome() {
+  const { t } = useTranslation();
+  const grouped = books.reduce((acc, b) => {
+    acc[b.type] = acc[b.type] || [];
+    acc[b.type].push(b);
+    return acc;
+  }, {});
+
+  return (
+    <div className="container mx-auto px-8 py-20">
+      <h1 className="text-4xl font-bold mb-8">{t('books.chooseBook')}</h1>
+      {Object.entries(grouped).map(([type, list]) => (
+        <div key={type} className="mb-8">
+          <h2 className="text-2xl font-semibold mb-4">{t(`bookTypes.${type}`)}</h2>
+          <ul className="space-y-2">
+            {list.map(book => (
+              <li key={book.slug}>
+                <Link
+                  to={`/creations/books/${book.type}/${book.slug}/overview`}
+                  className="text-blue-600 dark:text-blue-400 hover:underline"
+                >
+                  {book.title}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/data/books.js
+++ b/src/data/books.js
@@ -1,0 +1,22 @@
+export default [
+  {
+    type: 'novella',
+    slug: 'il-viaggio-misterioso',
+    title: 'Il Viaggio Misterioso',
+    description: 'Breve novella di esempio.',
+    chapters: [
+      { slug: 'capitolo-1', title: 'Capitolo 1', content: 'Testo del capitolo 1 della novella.' },
+      { slug: 'capitolo-2', title: 'Capitolo 2', content: 'Testo del capitolo 2 della novella.' }
+    ]
+  },
+  {
+    type: 'poetry',
+    slug: 'versi-dell-anima',
+    title: "Versi dell'anima",
+    description: 'Raccolta di poesie di esempio.',
+    chapters: [
+      { slug: 'poesia-1', title: 'Poesia 1', content: 'Nel cielo azzurro risplende il sole.' },
+      { slug: 'poesia-2', title: 'Poesia 2', content: 'Sotto la luna il mare riposa.' }
+    ]
+  }
+];

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -23,7 +23,7 @@
     "games":     "Games",
     "gamesDesc": "Dive into the WebGL prototype",
     "novel":     "Books",
-    "novelDesc": "Flip through my light novel",
+    "novelDesc": "Browse my books",
     "playGame": "Play now",
     "leaderboard": "Leaderboard",
     "chapter1Title": "Chapter 1",
@@ -50,6 +50,17 @@
   "stocazzato": {
     "title": "You are about to be stocazzato",
     "button": "Click here to evacuate ({{timer}})"
+  },
+  "books": {
+    "chooseBook": "Choose a book",
+    "overview": "Overview",
+    "chapters": "Chapters",
+    "next": "Next chapter",
+    "prev": "Previous chapter"
+  },
+  "bookTypes": {
+    "novella": "Novella",
+    "poetry": "Poetry"
   }
 
 }

--- a/src/locales/it/translation.json
+++ b/src/locales/it/translation.json
@@ -23,7 +23,7 @@
     "games":     "Giochi",
     "gamesDesc": "Immergiti nel prototipo WebGL",
     "novel":     "Libri",
-    "novelDesc": "Sfoglia la mia light novel",
+    "novelDesc": "Sfoglia i miei libri",
     "playGame": "Avvia il gioco",
     "leaderboard": "Classifica",
     "chapter1Title": "Capitolo 1",
@@ -50,5 +50,16 @@
   "stocazzato": {
     "title": "Stai per essere stocazzato",
     "button": "Clicca qui per evacuare ({{timer}})"
+  },
+  "books": {
+    "chooseBook": "Scegli un libro",
+    "overview": "Panoramica",
+    "chapters": "Capitoli",
+    "next": "Capitolo successivo",
+    "prev": "Capitolo precedente"
+  },
+  "bookTypes": {
+    "novella": "Novella",
+    "poetry": "Poesie"
   }
 }


### PR DESCRIPTION
## Summary
- add dataset for sample books
- create BooksHome, BookOverview and BookChapter components
- update Creations page to link new books
- wire up new routes in App
- extend Italian and English translations for books

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840084bbcc483218c6ac322533513b9