### PR TITLE
Fix book navigation without react-router

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -9,9 +9,7 @@ import WorkInProgress from './components/WorkInProgress';
 import History from './components/History';
 import CreationsPage from './components/CreationsPage';
 import Stocazzato from './components/Stocazzato';
-import BooksHome from './components/books/BooksHome';
-import BookOverview from './components/books/BookOverview';
-import BookChapter from './components/books/BookChapter';
+import BooksRouter from './components/books/BooksRouter';
 
 
 export default function App() {
@@ -27,9 +25,7 @@ export default function App() {
         {/* Rotta per gestire percorsi non definiti */}
         <Route path="*" element={<WorkInProgress />} />
         <Route path="/creations" element={<CreationsPage />} />
-        <Route path="/creations/books" element={<BooksHome />} />
-        <Route path="/creations/books/:type/:name/overview" element={<BookOverview />} />
-        <Route path="/creations/books/:type/:name/:chapter" element={<BookChapter />} />
+        <Route path="/creations/books/*" element={<BooksRouter />} />
         <Route path="/history" element={<History />} />
          <Route path="/stocazzato" element={<Stocazzato />} />
       </Routes>

--- a/src/components/books/BookChapter.js
+++ b/src/components/books/BookChapter.js
@@ -1,10 +1,22 @@
 import React from 'react';
-import { useParams, Link } from 'react-router-dom';
+// Manual hash-based navigation, avoiding react-router
 import { useTranslation } from 'react-i18next';
 import books from '../../data/books';
 
-export default function BookChapter() {
-  const { type, name, chapter } = useParams();
+export default function BookChapter({ type: propType, name: propName, chapter: propChapter }) {
+  let type = propType;
+  let name = propName;
+  let chapter = propChapter;
+  if (!type || !name || !chapter) {
+    const hash = window.location.hash.replace(/^#\/?/, '');
+    const parts = hash.split('/');
+    const idx = parts.indexOf('books');
+    if (idx !== -1) {
+      type = type || parts[idx + 1];
+      name = name || parts[idx + 2];
+      chapter = chapter || parts[idx + 3];
+    }
+  }
   const { t } = useTranslation();
   const book = books.find(b => b.type === type && b.slug === name);
   if (!book) return <div className="p-8">Book not found</div>;
@@ -21,20 +33,20 @@ export default function BookChapter() {
       <p className="mb-8 whitespace-pre-line">{ch.content}</p>
       <div className="flex justify-between">
         {prev ? (
-          <Link
-            to={`/creations/books/${type}/${name}/${prev}`}
+          <a
+            href={`#/creations/books/${type}/${name}/${prev}`}
             className="text-blue-600 dark:text-blue-400 hover:underline"
           >
             {t('books.prev')}
-          </Link>
+          </a>
         ) : <span />}
         {next ? (
-          <Link
-            to={`/creations/books/${type}/${name}/${next}`}
+          <a
+            href={`#/creations/books/${type}/${name}/${next}`}
             className="text-blue-600 dark:text-blue-400 hover:underline"
           >
             {t('books.next')}
-          </Link>
+          </a>
         ) : <span />}
       </div>
     </div>

--- a/src/components/books/BookOverview.js
+++ b/src/components/books/BookOverview.js
@@ -1,10 +1,20 @@
 import React from 'react';
-import { useParams, Link } from 'react-router-dom';
+// We avoid react-router here and parse the hash manually
 import { useTranslation } from 'react-i18next';
 import books from '../../data/books';
 
-export default function BookOverview() {
-  const { type, name } = useParams();
+export default function BookOverview({ type: propType, name: propName }) {
+  let type = propType;
+  let name = propName;
+  if (!type || !name) {
+    const hash = window.location.hash.replace(/^#\/?/, '');
+    const parts = hash.split('/');
+    const idx = parts.indexOf('books');
+    if (idx !== -1) {
+      type = parts[idx + 1];
+      name = parts[idx + 2];
+    }
+  }
   const { t } = useTranslation();
   const book = books.find(b => b.type === type && b.slug === name);
 
@@ -18,12 +28,12 @@ export default function BookOverview() {
       <ul className="list-disc list-inside space-y-1">
         {book.chapters.map(ch => (
           <li key={ch.slug}>
-            <Link
+            <a
               className="text-blue-600 dark:text-blue-400 hover:underline"
-              to={`/creations/books/${type}/${name}/${ch.slug}`}
+              href={`#/creations/books/${type}/${name}/${ch.slug}`}
             >
               {ch.title}
-            </Link>
+            </a>
           </li>
         ))}
       </ul>

--- a/src/components/books/BooksHome.js
+++ b/src/components/books/BooksHome.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+// Navigation is handled via hash links so we don't rely on react-router
 import { useTranslation } from 'react-i18next';
 import books from '../../data/books';
 
@@ -20,12 +20,12 @@ export default function BooksHome() {
           <ul className="space-y-2">
             {list.map(book => (
               <li key={book.slug}>
-                <Link
-                  to={`/creations/books/${book.type}/${book.slug}/overview`}
+                <a
+                  href={`#/creations/books/${book.type}/${book.slug}/overview`}
                   className="text-blue-600 dark:text-blue-400 hover:underline"
                 >
                   {book.title}
-                </Link>
+                </a>
               </li>
             ))}
           </ul>

--- a/src/components/books/BooksRouter.js
+++ b/src/components/books/BooksRouter.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import BooksHome from './BooksHome';
+import BookOverview from './BookOverview';
+import BookChapter from './BookChapter';
+
+function parseHash() {
+  const hash = window.location.hash.replace(/^#\/?/, '');
+  const parts = hash.split('/').filter(Boolean);
+  const idx = parts.indexOf('books');
+  if (idx === -1) return { view: 'home' };
+  const rest = parts.slice(idx + 1);
+  if (rest.length === 0) return { view: 'home' };
+  if (rest.length >= 3 && rest[2] === 'overview') {
+    return { view: 'overview', type: rest[0], name: rest[1] };
+  }
+  if (rest.length >= 3) {
+    return { view: 'chapter', type: rest[0], name: rest[1], chapter: rest[2] };
+  }
+  return { view: 'home' };
+}
+
+export default function BooksRouter() {
+  const [state, setState] = React.useState(parseHash());
+  React.useEffect(() => {
+    const onHash = () => setState(parseHash());
+    window.addEventListener('hashchange', onHash);
+    return () => window.removeEventListener('hashchange', onHash);
+  }, []);
+
+  if (state.view === 'overview') {
+    return <BookOverview type={state.type} name={state.name} />;
+  }
+  if (state.view === 'chapter') {
+    return <BookChapter type={state.type} name={state.name} chapter={state.chapter} />;
+  }
+  return <BooksHome />;
+}


### PR DESCRIPTION
## Summary
- drop use of `react-router-dom` inside book components
- add `BooksRouter` to handle hash-based navigation
- update `App` to use new router for `/creations/books/*`

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_68401320a5b8832188ecb06b3150daf0